### PR TITLE
feature(packaging): Add packaging support for .deb & .rpm

### DIFF
--- a/packaging/CMakeLists.txt
+++ b/packaging/CMakeLists.txt
@@ -1,0 +1,44 @@
+cmake_minimum_required(VERSION 3.16)
+project(ChangelogFragmentsCreator VERSION 1.0)
+
+install(FILES ../changelog-creator DESTINATION bin)
+
+# General
+set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/../LICENSE")
+set(CPACK_RESOURCE_FILE_README "${CMAKE_CURRENT_SOURCE_DIR}/../README.md")
+set(CPACK_DEBIAN_PACKAGE_MAINTAINER "Florian Paul Azim <gyptazy> Hoberg <gyptazy@gyptazy.ch>")
+set(CPACK_PACKAGE_CONTACT "Florian Paul Azim Hoberg <gyptazy@gyptazy.ch)")
+set(CPACK_PACKAGE_VENDOR "gyptazy")
+
+# RPM packaging
+set(CPACK_PACKAGE_VERSION ${CMAKE_PROJECT_VERSION})
+set(CPACK_GENERATOR "RPM")
+set(CPACK_RPM_PACKAGE_ARCHITECTURE "noarch")
+set(CPACK_PACKAGE_NAME "changelog-fragments-creator")
+set(CPACK_RPM_PACKAGE_SUMMARY "changelog-creater - A tool to create a complete changelog by changelog fragments.")
+set(CPACK_RPM_PACKAGE_DESCRIPTION "changelog-creater - A tool to create a complete changelog by changelog fragments.")
+set(CPACK_RPM_CHANGELOG_FILE "${CMAKE_CURRENT_SOURCE_DIR}/rpm_changelog.txt")
+set(CPACK_PACKAGE_RELEASE 1)
+set(CPACK_RPM_PACKAGE_LICENSE "GPL 3.0")
+set(CPACK_RPM_PACKAGE_REQUIRES "python >= 3.2.0, python3-pyyaml")
+
+# DEB packaging
+set(CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)
+set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "noarch")
+set(CPACK_DEBIAN_PACKAGE_SUMMARY "changelog-creater - A tool to create a complete changelog by changelog fragments.")
+set(CPACK_DEBIAN_PACKAGE_DESCRIPTION "changelog-creater - A tool to create a complete changelog by changelog fragments.")
+set(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA "${CMAKE_CURRENT_SOURCE_DIR}/deb_changelog.txt")
+set(CPACK_DEBIAN_PACKAGE_REQUIRES "python3-yaml")
+
+
+# FreeBSD packaging
+set(CPACK_FREEBSD_PACKAGE_ARCHITECTURE "noarch")
+set(CPACK_FREEBSD_PACKAGE_SUMMARY "changelog-creater - A tool to create a complete changelog by changelog fragments.")
+set(CPACK_FREEBSD_PACKAGE_DESCRIPTION "changelog-creater - A tool to create a complete changelog by changelog fragments.")
+set(CPACK_FREEBSD_PACKAGE_CONTROL_EXTRA "${CMAKE_CURRENT_SOURCE_DIR}/fbsd_changelog.txt")
+set(CPACK_FREEBSD_PACKAGE_REQUIRES "python3-yaml")
+
+
+# Install
+set(CPACK_PACKAGING_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX})
+include(CPack)

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -1,0 +1,7 @@
+
+run:
+mkdir build
+cd build
+cmake ..
+cpack -G RPM .
+cpack -G DEB .

--- a/packaging/deb_changelog.txt
+++ b/packaging/deb_changelog.txt
@@ -1,0 +1,5 @@
+changelog-fragments-creator (1.0.0) unstable; urgency=low
+
+  * Initial release of changelog-creater for changelog fragments
+
+ -- Florian Paul Azim Hoberg <gyptazy@gyptazy.ch>  Sat, 05 Aug 2023 23:07:17 -0200

--- a/packaging/fbsd_changelog.txt
+++ b/packaging/fbsd_changelog.txt
@@ -1,0 +1,2 @@
+2023-08-05:
+    Initial release of changelog-creater for changelog fragments

--- a/packaging/rpm_changelog.txt
+++ b/packaging/rpm_changelog.txt
@@ -1,0 +1,2 @@
+* Sat Aug 05 2023 Florian Paul Azim Hoberg <gyptazy@gyptazy.ch>
+- Initial release of changelog-creater for changelog fragments


### PR DESCRIPTION
Add initial packaging support for:
* Debian/Ubuntu (GardenLinux) based .deb distributions
* RedHat/CentOS (Fedora) based .rpm distributions
* FreeBSD (FBSD) support